### PR TITLE
Added index to secret name

### DIFF
--- a/helm/rosetta-website-nginx/templates/ingress.yaml
+++ b/helm/rosetta-website-nginx/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
         {{- range $tls.hosts }}
         - {{ $hostOverride }}
         {{- end }}
-      secretName: {{ $releaseName }}-{{ $tls.secretName }}
+      secretName: {{ $releaseName }}-{{ $tls.secretName }}-{{ $i }}
     {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
All that is required is `helm template rosetta-website` and then inspect the ingress.yaml. E.g.
`helm template rosetta-website-nginx --debug --set global.hostnameOverride="{mike,joe}"`

I ran this and it gave:
```
spec:
  tls:
    - hosts:
        - mike
      secretName: RELEASE-NAME-cert-0
    - hosts:
        - joe
      secretName: RELEASE-NAME-cert-1
  rules:
    - host: mike
      http:
        paths:
          - path: /
            backend:
              serviceName: RELEASE-NAME-rosetta-website-nginx
              servicePort: 80
    - host: joe
      http:
        paths:
          - path: /
            backend:
              serviceName: RELEASE-NAME-rosetta-website-nginx
              servicePort: 80
```
So we are all good.
